### PR TITLE
Add `enforce: post` to run after the bundling is completed

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -85,6 +85,7 @@ export default function zipPack(options?: Options): PluginOption {
   return {
     name: "vite-plugin-zip-pack",
     apply: "build",
+    enforce: "post",
     closeBundle() {
       try {
         console.log("\x1b[36m%s\x1b[0m", `Zip packing - "${inDir}" folder :`);


### PR DESCRIPTION
The packing should happen at the end of all other processes to ensure all the files are included.

Read more: [https://vitejs.dev/guide/api-plugin#plugin-ordering](https://vitejs.dev/guide/api-plugin#plugin-ordering)

Fixes: #7 