### PR TITLE
Recursively create parent directories for outDir

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -121,7 +121,7 @@ export default function zipPack(options?: Options): PluginOption {
         }
 
         if (!fs.existsSync(outDir)) {
-          await fs.promises.mkdir(outDir)
+          await fs.promises.mkdir(outDir, { recursive: true });
         }
 
         if (pathPrefix && path.isAbsolute(pathPrefix)) {


### PR DESCRIPTION
If outDir is a path with parent folders that don't exist, it will fail:
```
- Error: ENOENT: no such file or directory, mkdir '/Users/chauber/.../{outDir}'
- Something went wrong while building zip file!
```

This is because it won't recursively create parent directories by default. Adding `{ recursive: true }` enables this, which I believe is adding the `-p` tag to the `mkdir` command under the hood (or an equivalent of that).